### PR TITLE
fix lack of _sub_plugin var in base PersistentConnection

### DIFF
--- a/plugins/plugin_utils/connection_base.py
+++ b/plugins/plugin_utils/connection_base.py
@@ -55,6 +55,8 @@ class PersistentConnectionBase(ConnectionBase):
         self._messages = []
         self._conn_closed = False
 
+        self._sub_plugin = {}
+
         self._local = connection_loader.get("local", play_context, "/dev/null")
         self._local.set_options()
 


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
