### PR TITLE
Add error message when failing to open plc

### DIFF
--- a/plugins/module_utils/logix.py
+++ b/plugins/module_utils/logix.py
@@ -13,6 +13,7 @@ try:
 except ImportError:
     HAS_PYCOMM3 = False
 
+
 class LogixUtil(object):
     def __init__(self, module):
         self.module = module
@@ -29,7 +30,9 @@ class LogixUtil(object):
         try:
             self.plc.open()
         except (CommError, ResponseError) as error:
-            self.module.fail_json("Failed to open ControlLogix device %s, returned error message: (%s) Make sure this host is a PLC." % (self.logix_address, error))
+            self.module.fail_json(
+                "Failed to open ControlLogix device %s, returned error message: (%s) Make sure this host is a PLC." % (self.logix_address, error)
+            )
 
         if not self.plc.connected:
             self.module.fail_json(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add error message when failing to open plc, pass error message from pycomm3

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
