### PR TITLE
Galaxy and Execution Environment Config Fixes

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: community
 name: cip
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.0.1
+version: 1.0.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -29,8 +29,8 @@ description: Collection to automate Programmable Logic Controllers
 
 # Either a single license or a list of licenses for content inside of a collection. Ansible Galaxy currently only
 # accepts L(SPDX,https://spdx.org/licenses/) licenses. This key is mutually exclusive with 'license_file'
-license:
-- MIT
+#license:
+#- MIT
 
 # The path to the license file for the collection. This path is relative to the root of the collection. This key is
 # mutually exclusive with 'license'

--- a/meta/rumtime.yml
+++ b/meta/rumtime.yml
@@ -1,3 +1,0 @@
----
-
-requires_ansible: ">=2.12"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,3 @@
+---
+
+requires_ansible: ">=2.12"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When pushing to a private automation hub/execution environment, I found a few bugs in the configuration files:
- Collection version needed to be set to 1.0.0 for initial release
- `license_file` and `license` options were both specified in `galaxy.yml`, and they are mutually exclusive
- `meta/runtime.yml` seemed to have be created by Jack Sparrow https://media.giphy.com/media/11tdsyM4aWo8dq/giphy.gif

Related to #13 and #23, but does not fix them
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
