### PR TITLE
Replace PersistentConnectionBase with ansible.utils' version

### DIFF
--- a/plugins/connection/logix.py
+++ b/plugins/connection/logix.py
@@ -112,7 +112,6 @@ class Connection(PersistentConnectionBase):
             )
 
         self.host = self.get_option("host")
-        self._sub_plugin = {"type": "external"}
 
     def _connect(self):
         if not self.connected:

--- a/plugins/plugin_utils/connection_base.py
+++ b/plugins/plugin_utils/connection_base.py
@@ -2,7 +2,7 @@
 # (c) 2015 Toshio Kuratomi <tkuratomi@ansible.com>
 # (c) 2017, Peter Sprygada <psprygad@redhat.com>
 # (c) 2017 Ansible Project
-# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 

--- a/plugins/plugin_utils/connection_base.py
+++ b/plugins/plugin_utils/connection_base.py
@@ -2,7 +2,8 @@
 # (c) 2015 Toshio Kuratomi <tkuratomi@ansible.com>
 # (c) 2017, Peter Sprygada <psprygad@redhat.com>
 # (c) 2017 Ansible Project
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 
 ##############################################################################
@@ -10,7 +11,7 @@
 #
 # This entire file can go away as soon as this PR (or some iteration of it)
 # is merged upstream and released so we can then depend on it:
-# https://github.com/ansible-collections/ansible.netcommon/pull/470
+# https://github.com/ansible-collections/ansible.utils/pull/213
 #
 # Currently vendoring this so we don't run into a library behavioral change
 # in Ansible Core 2.12 and newer that was causing failures for our
@@ -19,6 +20,7 @@
 
 
 from __future__ import absolute_import, division, print_function
+
 
 __metaclass__ = type
 
@@ -30,12 +32,11 @@ from ansible.plugins.loader import connection_loader
 from ansible.utils.display import Display
 from ansible.utils.path import unfrackpath
 
+
 display = Display()
 
 
-__all__ = ["NetworkConnectionBase", "PersistentConnectionBase"]
-
-BUFSIZE = 65536
+__all__ = ["PersistentConnectionBase"]
 
 
 class PersistentConnectionBase(ConnectionBase):
@@ -48,13 +49,9 @@ class PersistentConnectionBase(ConnectionBase):
     _remote_is_local = True
 
     def __init__(self, play_context, new_stdin, *args, **kwargs):
-        super(PersistentConnectionBase, self).__init__(
-            play_context, new_stdin, *args, **kwargs
-        )
+        super(PersistentConnectionBase, self).__init__(play_context, new_stdin, *args, **kwargs)
         self._messages = []
         self._conn_closed = False
-
-        self._sub_plugin = {}
 
         self._local = connection_loader.get("local", play_context, "/dev/null")
         self._local.set_options()
@@ -95,8 +92,7 @@ class PersistentConnectionBase(ConnectionBase):
         if self._socket_path:
             self.queue_message(
                 "vvvv",
-                "resetting persistent connection for socket_path %s"
-                % self._socket_path,
+                "resetting persistent connection for socket_path %s" % self._socket_path,
             )
             self.close()
         self.queue_message("vvvv", "reset call on connection instance")
@@ -134,68 +130,3 @@ class PersistentConnectionBase(ConnectionBase):
     def _log_messages(self, message):
         if self.get_option("persistent_log_messages"):
             self.queue_message("log", message)
-
-
-class NetworkConnectionBase(PersistentConnectionBase):
-    """
-    A base class for network-style connections using a sub-plugin.
-    """
-
-    def __init__(self, play_context, new_stdin, *args, **kwargs):
-        super(NetworkConnectionBase, self).__init__(
-            play_context, new_stdin, *args, **kwargs
-        )
-        self._network_os = self._play_context.network_os
-        self._sub_plugin = {}
-        self._cached_variables = (None, None, None)
-
-    def __getattr__(self, name):
-        try:
-            return self.__dict__[name]
-        except KeyError:
-            if not name.startswith("_"):
-                plugin = self._sub_plugin.get("obj")
-                if plugin:
-                    method = getattr(plugin, name, None)
-                    if method is not None:
-                        return method
-            raise AttributeError(
-                "'%s' object has no attribute '%s'" % (self.__class__.__name__, name)
-            )
-
-    def get_options(self, hostvars=None):
-        options = super(NetworkConnectionBase, self).get_options(hostvars=hostvars)
-
-        if self._sub_plugin.get("obj") and self._sub_plugin.get("type") != "external":
-            try:
-                options.update(self._sub_plugin["obj"].get_options(hostvars=hostvars))
-            except AttributeError:
-                pass
-
-        return options
-
-    def set_options(self, task_keys=None, var_options=None, direct=None):
-        super(NetworkConnectionBase, self).set_options(
-            task_keys=task_keys, var_options=var_options, direct=direct
-        )
-        if self.get_option("persistent_log_messages"):
-            warning = (
-                "Persistent connection logging is enabled for %s. This will log ALL interactions"
-                % self._play_context.remote_addr
-            )
-            logpath = getattr(C, "DEFAULT_LOG_PATH")
-            if logpath is not None:
-                warning += " to %s" % logpath
-            self.queue_message(
-                "warning",
-                "%s and WILL NOT redact sensitive configuration like passwords. USE WITH CAUTION!"
-                % warning,
-            )
-
-        if self._sub_plugin.get("obj") and self._sub_plugin.get("type") != "external":
-            try:
-                self._sub_plugin["obj"].set_options(
-                    task_keys=task_keys, var_options=var_options, direct=direct
-                )
-            except AttributeError:
-                pass


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
PersistentConnectionBase is intended to work around the need for `self._sub_plugin` entirely.

This PR updates the base plugin to the current version and removes the unnecessary NetworkConnectionBase class.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
logix

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
