### PR TITLE
generic_message data type fix

### DIFF
--- a/docs/example/generic_message.yml
+++ b/docs/example/generic_message.yml
@@ -4,7 +4,7 @@
   gather_facts: false
   tasks:
   - name: Get MAC address of EN2T device
-    industrial.logix.generic_message:
+    community.cip.generic_message:
       service: 0x0E
       class_code: 0xF6
       instance: 1
@@ -14,7 +14,7 @@
         array_len: 6
 
   - name: Find the IP Setting configuration type. 0b_0000 = 'static', 0b_0001 = 'BOOTP' 0b_0010 = 'DHCP'
-    industrial.logix.generic_message:
+    community.cip.generic_message:
       service: 0x0E
       class_code: 0xf5
       instance: 1

--- a/plugins/modules/generic_message.py
+++ b/plugins/modules/generic_message.py
@@ -141,7 +141,7 @@ def main():
         attribute=dict(required=False, default="", type="str"),
         request_data=dict(required=False, default="", type="str"),
         data_type=dict(
-            required=False, default=None, type="dict", options=dtspec
+            required=False, default={}, type="dict", options=dtspec
         ),
         name=dict(required=False, default="generic", type="str"),
     )
@@ -160,7 +160,7 @@ def main():
     # object. This is gonna be messy
     dt_arg = module.params["data_type"]
     data_type = None
-    if dt_arg is not None:
+    if dt_arg is not {}:
         if DataTypes.get(dt_arg["elementary_type"]) is None:
             module.fail_json(
                 f'elementary_type {dt_arg["elementary_type"]} is not one of',

--- a/plugins/modules/generic_message.py
+++ b/plugins/modules/generic_message.py
@@ -179,6 +179,8 @@ def main():
     request_data = module.params["request_data"]
     if not request_data:
         request_data = b""
+    else:
+        request_data = bytes(int(request_data, 0)),
 
     ret = logix_util.plc.generic_message(
         service=int(
@@ -187,7 +189,7 @@ def main():
         class_code=int(module.params["class_code"], 0),
         instance=int(module.params["instance"], 0),
         attribute=int(to_bytes(module.params["attribute"]), 0),
-        request_data=bytes(int(request_data, 0)),
+        request_data=request_data,
         data_type=data_type,
         name=module.params["name"],
         connected=False,  # TODO: Double check all connection stuff


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
CI tests are currently failing due to a mismatch in documented and implemented default value for the `data_type` value of the generic_message task. This fixes that. 

TODO:
- [x] Sufficiently test
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
generic_message

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
